### PR TITLE
Dockerignore all the node_module files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+**/node_modules

--- a/client/.dockerignore
+++ b/client/.dockerignore
@@ -1,0 +1,1 @@
+**/node_modules

--- a/services/server/.dockerignore
+++ b/services/server/.dockerignore
@@ -1,0 +1,1 @@
+**/node_modules

--- a/services/telemetry/.dockerignore
+++ b/services/telemetry/.dockerignore
@@ -1,0 +1,1 @@
+**/node_modules


### PR DESCRIPTION
This makes it so that you don't have to delete node modules directories before
running docker.
