### PR TITLE
Fix config bug to use remote db if needed

### DIFF
--- a/services/server/src/config/config.ts
+++ b/services/server/src/config/config.ts
@@ -6,9 +6,9 @@ dotenv.config();
 const MONGO_USERNAME = process.env.MONGO_USERNAME || '';
 const MONGO_PASSWORD = process.env.MONGO_PASSWORD || '';
 const MONGO_DB_STRING = process.env.MONGO_DB_STRING || '';
-const MONGO_LOCAL = process.env.MONOG_LOCAL || 'True';
+const MONGO_LOCAL = process.env.MONGO_LOCAL || 'True';
 
-const Local_DB = (MONGO_LOCAL == 'True');
+const Local_DB = (MONGO_LOCAL === 'True');
 
 const MONGO_URL_REMOTE = `mongodb+srv://${MONGO_USERNAME}:${MONGO_PASSWORD}@groundsupport.${MONGO_DB_STRING}.mongodb.net/`;
 const MONGO_URL_LOCAL = `mongodb://${MONGO_USERNAME}:${MONGO_PASSWORD}@db:27017/${MONGO_DB_STRING}?authSource=admin`;


### PR DESCRIPTION
Fixing a bug I introduced with https://github.com/UVicRocketry/Ground-Support/pull/58, where we could only use the local db instance, regardless of the `MONGO_LOCAL` value in `.env`. Now, the server connects to the local DB if `MONGO_LOCAL` is true, otherwise it connects to the the remote db.