### PR TITLE
Connect flight-data-reader submodule for data upload

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "client/flight-data-reader"]
 	path = client/flight-data-reader
-	url = https://github.com/mas393/flight-data-reader.git
-	branch = ground-support-support
+	url = https://github.com/PokeyOne/flight-data-reader.git
+	branch = trunk

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "client/flight-data-reader"]
+	path = client/flight-data-reader
+	url = https://github.com/mas393/flight-data-reader.git
+	branch = ground-support-support

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,7 +1,15 @@
+FROM rust:1.73 as flight-data-reader
+
+RUN cargo install wasm-pack
+COPY flight-data-reader /usr/src/flight-data-reader
+WORKDIR /usr/src/flight-data-reader/web_package/rocket-data
+RUN wasm-pack build
+
 FROM node:18-alpine as base
 
 FROM base as dev
 WORKDIR /app
+COPY --from=flight-data-reader /usr/src/flight-data-reader/web_package/rocket-data/pkg rocket-data
 RUN --mount=type=bind,source=package.json,target=package.json \
     --mount=type=cache,target=/root/.cache/yarn \
     yarn install

--- a/client/package.json
+++ b/client/package.json
@@ -25,8 +25,11 @@
 		"react-dom": "^18.2.0",
 		"react-material-file-upload": "^0.0.4",
 		"react-syntax-highlighter": "^15.5.0",
+		"rocket-data": "file:./rocket-data",
 		"socket-io": "^1.0.0",
 		"typescript": "^4.8.4",
+		"vite-plugin-top-level-await": "^1.3.1",
+		"vite-plugin-wasm": "^3.2.2",
 		"web-vitals": "^2.1.4"
 	},
 	"scripts": {

--- a/client/src/components/DataUpload.tsx
+++ b/client/src/components/DataUpload.tsx
@@ -3,6 +3,7 @@ import { useActiveMission } from "../utils/ActiveMissionContext";
 import React, { useState, forwardRef, useEffect } from 'react';
 import { TransitionProps } from "@mui/material/transitions";
 import FileUpload from "react-material-file-upload";
+import * as DataConverter from "rocket-data"
 
 
 
@@ -18,6 +19,7 @@ const MissionConfig: React.FC<IDataUploadProps> = (props: IDataUploadProps) => {
     
     const handleSave = () => {
         // TODO: mateos rust library
+        DataConverter.greet();
         props.onClose();
     };
 
@@ -43,9 +45,7 @@ const MissionConfig: React.FC<IDataUploadProps> = (props: IDataUploadProps) => {
                         <Typography variant="subtitle1">Supported File Type:</Typography>
                         <Chip label='.cvs' color="primary" variant="outlined"/> 
                         <Chip label='.json' color="primary" variant="outlined"/> 
-                        <Tooltip title="Raw data. not Supported yet">
-                            <Chip label='.bin' color="error" variant="outlined" />
-                        </Tooltip>
+                        <Chip label='.bin' color="primary" variant="outlined"/>
                     </Stack>
                     <Tooltip title="To upload multiple files they both must be selected in your file system">
                         <div>

--- a/client/src/components/DataUpload.tsx
+++ b/client/src/components/DataUpload.tsx
@@ -17,8 +17,8 @@ const MissionConfig: React.FC<IDataUploadProps> = (props: IDataUploadProps) => {
     const [files, setFiles] = useState<File[]>([]);
     
     const handleSave = async () => {
-        const config_file = files.find((element: File) => element.type === "application/json");
-        const bin_file = files.find((element: File) => element.type === "application/macbinary");
+        const config_file = files.find((element: File) => element.name.indexOf(".json") !== -1);
+        const bin_file = files.find((element: File) => element.name.indexOf(".bin") !== -1);
         const csv_str = await DataConverter.convert_to_csv(config_file, bin_file);
         console.log(csv_str);
         props.onClose();

--- a/client/src/components/DataUpload.tsx
+++ b/client/src/components/DataUpload.tsx
@@ -1,7 +1,6 @@
-import { Button, Chip, Dialog, DialogActions, DialogContent, DialogTitle, Slide, Stack, Tooltip, Typography } from "@mui/material";
+import { Button, Chip, Dialog, DialogActions, DialogContent, DialogTitle, Stack, Tooltip, Typography } from "@mui/material";
 import { useActiveMission } from "../utils/ActiveMissionContext";
-import React, { useState, forwardRef, useEffect } from 'react';
-import { TransitionProps } from "@mui/material/transitions";
+import React, { useState, useEffect } from 'react';
 import FileUpload from "react-material-file-upload";
 import * as DataConverter from "rocket-data"
 
@@ -17,9 +16,11 @@ const MissionConfig: React.FC<IDataUploadProps> = (props: IDataUploadProps) => {
     const { isOpen, onClose } = props;
     const [files, setFiles] = useState<File[]>([]);
     
-    const handleSave = () => {
-        // TODO: mateos rust library
-        DataConverter.greet();
+    const handleSave = async () => {
+        const config_file = files.find((element: File) => element.type === "application/json");
+        const bin_file = files.find((element: File) => element.type === "application/macbinary");
+        const csv_str = await DataConverter.convert_to_csv(config_file, bin_file);
+        console.log(csv_str);
         props.onClose();
     };
 

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,10 +1,15 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import viteTsconfigPaths from'vite-tsconfig-paths';
+import wasm from 'vite-plugin-wasm';
+import topLevelAwait from 'vite-plugin-top-level-await';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react(), viteTsconfigPaths()],
+  plugins: [react(),
+            viteTsconfigPaths(),
+            wasm(), 
+            topLevelAwait()],
   server: {
     host: true,
     watch: {

--- a/documentation/installation.md
+++ b/documentation/installation.md
@@ -59,6 +59,14 @@ Now if you haven't already you can clone the repository
 ```bash
 git clone https://github.com/UVicRocketry/Ground-Support.git
 ```
+
+Then clone project submodules
+
+```bash
+cd Ground-Support
+git submodule update --init --recursive
+```
+
 **Server Environment File**
 
 In the `/services/server` directory create a `.env` file. If not called exactly `.env`, create one and copy and paste


### PR DESCRIPTION
This PR links Ground Support with Mateo's [flight data reader wasm library](https://github.com/PokeyOne/flight-data-reader) to parse uploaded binary flight data into csv format for storage in the DB. A followup task will load the csv data into the DB.

[Trello task](https://trello.com/c/imZRzuKu/2-flight-data-upload)