### PR TITLE
Add new command line option to telemetry service to use binaries in path instead of the vendored

### DIFF
--- a/client/src/components/rocket-monitoring/TelemetryAltitudeGraph.tsx
+++ b/client/src/components/rocket-monitoring/TelemetryAltitudeGraph.tsx
@@ -13,16 +13,16 @@ const TelemetryAltitudeGraph: React.FC = () => {
     }
     const [data, setData] = useState<IAltitudeData[]>([]);
     useEffect(() => {
-        if ((socketContext.packet && socketContext.isConnected)) {        
+        if ((socketContext.packet && socketContext.isConnected && socketContext.packet?.data)) {
             setData((prev) => [
-                ...prev, 
+                ...prev,
                 {
                     Id: socketContext.packet.id,
                     Altitude: socketContext.packet.data.altitude
                 }
             ]);
         }
-    }, [socketContext.packet]); 
+    }, [socketContext.packet]);
 
     return (
         <Paper
@@ -37,20 +37,20 @@ const TelemetryAltitudeGraph: React.FC = () => {
             <Typography variant='h6' fontWeight={600}>
                 Real Time Altitude
             </Typography>
-            <ResponsiveContainer 
-                width="100%" 
-                height={208} 
+            <ResponsiveContainer
+                width="100%"
+                height={208}
             >
-                <LineChart 
+                <LineChart
                     data={data}
                 >
-                    <XAxis 
-                        dataKey="Id" 
-                        domain={['auto', 'auto']} 
+                    <XAxis
+                        dataKey="Id"
+                        domain={['auto', 'auto']}
                     />
-                    <YAxis 
-                        orientation='right' 
-                        dataKey={"Altitude"}  
+                    <YAxis
+                        orientation='right'
+                        dataKey={"Altitude"}
                         domain={[0, 'auto']}
                     />
                     <Tooltip />

--- a/client/src/components/rocket-monitoring/TelemetryPacket.tsx
+++ b/client/src/components/rocket-monitoring/TelemetryPacket.tsx
@@ -12,7 +12,7 @@ const TelemetryPacket: React.FC = () => {
     const [altitude, setAltitude] = useState<number>(0);
 
     useEffect(() => {
-        if ((socketContext.packet && socketContext.isConnected)) {        
+        if ((socketContext.packet && socketContext.isConnected && socketContext.packet?.data)) {
             setPacketId(socketContext.packet.id);
             setAltitude(socketContext.packet.data.altitude);
         }

--- a/services/telemetry/src/main.rs
+++ b/services/telemetry/src/main.rs
@@ -43,6 +43,10 @@ struct Cli {
     /// server. This is currently meant for testing purposes.
     #[clap(long)]
     client: bool,
+    /// When this option is set, the binaries installed on the system will be
+    /// used instead of the ones in the repo.
+    #[clap(long)]
+    system_binaries: bool
 }
 
 /// A transmission protocol that is used to transmit data from the rocket.

--- a/services/telemetry/src/state.rs
+++ b/services/telemetry/src/state.rs
@@ -19,6 +19,8 @@ pub struct State {
     /// buffer. This offset is used to keep track of the first packet in the
     /// packet buffer.
     pub packet_buffer_offset: u64,
+    /// When true, system-wide binaries are used instead of the ones in the repo.
+    pub system_binaries: bool
 }
 
 impl State {
@@ -31,6 +33,7 @@ impl State {
             last_packet_id: None,
             packet_buffer: Vec::new(),
             packet_buffer_offset: 0,
+            system_binaries: false
         }
     }
 

--- a/services/telemetry/src/telemetry.rs
+++ b/services/telemetry/src/telemetry.rs
@@ -58,13 +58,19 @@ pub async fn start_telemetry(state_ref: Arc<Mutex<State>>) -> io::Result<()> {
     let frequency = state_ref.lock().unwrap().frequency;
     println!("Starting telemetry on {}", frequency);
 
+    let decode_script_path = if state_ref.lock().unwrap().system_binaries {
+        "./tools/decode.sh"
+    } else {
+        "./tools/decode_with_sys_bin.sh"
+    };
+
     let mut decode_aprs = Command::new("sh")
-        .arg("./tools/decode_test.sh")
+        .arg(decode_script_path)
         // .arg(frequency.to_string())
         .stdout(Stdio::piped())
         .spawn()
         .expect("failed to start decoder");
-    
+
     let mut child_out = BufReader::new(decode_aprs.stdout.as_mut().unwrap());
     let mut readbuf = vec![0; 256];
 

--- a/services/telemetry/tools/decode_test.sh
+++ b/services/telemetry/tools/decode_test.sh
@@ -1,2 +1,2 @@
 # -u = no buffering on stdout.
-python -u ./tools/test_data.py
+python3 -u ./tools/test_data.py

--- a/services/telemetry/tools/decode_with_sys_bin.sh
+++ b/services/telemetry/tools/decode_with_sys_bin.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+
+# This script is used to decode APRS packets from the RTL-SDR dongle
+#
+# This version is for using system-wide binaries instead of in the repo.
+
+if [ $# -ge 1 ]
+then
+  FREQ=$1
+else
+  FREQ=433.92M
+fi
+
+rtl_fm -f $FREQ -r 24k -s 260k -o 4 -p 93 -g 49.6 - | direwolf -c ./tools/direwolf.conf -n 1 -r 24000 -b 16 -


### PR DESCRIPTION
Also fix a bug where the site crashes when empty packets are received


Now when you run the telemetry service, you can do something like:
```bash
cargo run -- --system-binaries
```

And instead of using `./tools/rtl_fm` and `./tools/direwolf`, it will just use `rtl_fm` and `direwolf`. This is so that on other devices, like my mac, I can run it with binaries that I already have installed on my computer.

This also fixes a bug where when you were using an SDR but don't have a lock with data, it would crash because it was trying to get the packet data when there was no data. So this just adds a couple extra checks to prevent that. 